### PR TITLE
Add suporte para banco de dados MSSQL Server 2017+

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ SQLite            | 3.26.0+   |  ✅
 Mysql             | 5.7+      |  ✅     
 MariaDB           | 10.3+     |  ✅    
 PostgreSQL        | 10.0+     |  ✅  
-SQLServer         | -         | ❌
+SQLServer         | 2017+     |  ✅
 
 
 ### Contributing
@@ -62,10 +62,10 @@ Please, fork this repository, make any changes and submit a Pull Request and we 
 
 ### Contributors
 
-| <a href="http://jdsantos.github.io" target="_blank">**Jorge Santos**</a>
-|:---:|
-| [![jdsantos](https://avatars1.githubusercontent.com/u/1708961?v=3&s=50)](http://jdsantos.github.io)    | 
-| <a href="https://github.com/jdsantos" target="_blank">`github.com/jdsantos`</a>
+| <a href="https://jdsantos.github.io" target="_blank">**Jorge Santos**</a> | <a href="https://walissonaguirra.github.io" target="_blank">**Walisson Aguirra**</a> |
+|:---:|:---:|
+| [![jdsantos](https://avatars1.githubusercontent.com/u/1708961?v=3&s=50)](http://jdsantos.github.io) | [![walissonaguirra](https://avatars.githubusercontent.com/u/53498071?v=4&s=50)](https://github.com/walissonaguirra) |
+| <a href="https://github.com/jdsantos" target="_blank">`github.com/jdsantos`</a> | <a href="https://github.com/walissonaguirra" target="_blank">`github.com/walissonaguirra`</a> |
 
 ### Support
 

--- a/src/Handlers/ConcreteStubConfigurator.php
+++ b/src/Handlers/ConcreteStubConfigurator.php
@@ -15,6 +15,7 @@ class ConcreteStubConfigurator implements StubConfigurator
         'mysql',
         'mariadb',
         'pgsql',
+        'mssql',
     ];
 
     /**

--- a/src/Stubs/databases/mssql.stub
+++ b/src/Stubs/databases/mssql.stub
@@ -1,0 +1,19 @@
+# Instalar extensões PHP para SQL Server
+RUN set -ex; \
+    apk --no-cache add \
+        unixodbc-dev \
+        curl \
+        $PHPIZE_DEPS \
+    ; \
+    \
+    # Baixa e instala o driver ODBC da Microsoft para SQL Server
+    curl -fsSL https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_18.3.3.1-1_amd64.apk -o /tmp/msodbcsql18.apk; \
+    apk add --allow-untrusted /tmp/msodbcsql18.apk; \
+    \
+    # Instalar extensões PHP sqlsrv e pdo_sqlsrv via PECL
+    pecl install sqlsrv pdo_sqlsrv; \
+    \
+    # Habilitar as extensões
+    docker-php-ext-enable sqlsrv pdo_sqlsrv; \
+    \
+    rm -rf /tmp/*;


### PR DESCRIPTION
Este pull request introduz o suporte para o Microsoft SQL Server 2017/2022  (MS SQL Server) no Laradocker.

- Add driver do MS SQL Server: Foi incluído um novo stub (mssql.stub) que automatiza a instalação das extensões PHP `sqlsrv` e `pdo_sqlsrv`, necessárias para a comunicação com o SQL Server.
- Atualização da Documentação: O arquivo README.md foi atualizado para refletir a adição do MS SQL Server na lista de bancos de dados suportados.
- Créditos: Adicionei meu nome à lista de contribuidores.

---

Testado com mssql 2017 e 2022
```yml
  mssql:
    image: mcr.microsoft.com/mssql/server:2022-latest
    environment:
      SA_PASSWORD: "AW|3Cl6P,[=6ATmpGk>f"
      ACCEPT_EULA: Y
      MSSQL_PID: "Developer"
    ports:
      - "1433:1433"
```

|Print terminal|
|:---:|
|<img width="891" height="307" alt="image" src="https://github.com/user-attachments/assets/21e2df8a-03a5-46cf-9b61-726ac67412d9" />|

---

**Nota:**
Senti falta de uma documentação descrevendo como prepara um ambiente de desenvolvimento para o Laradocker, talvez possamos abrir uma issues sobre isso